### PR TITLE
Change token in it and describe blocks

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -41,7 +41,7 @@
       {
         'begin': '\\s([\'\"])'
         'end': '\\1'
-        'name': 'entity.name.rspec'
+        'name': 'string'
       }
       {
         'begin': '(,)'
@@ -70,7 +70,7 @@
       {
         'begin': '\\s([\'\"])'
         'end': '\\1'
-        'name': 'entity.name.rspec'
+        'name': 'string'
       }
       {
         'begin': '(,)'
@@ -90,7 +90,7 @@
       '1':
         'name': 'keyword.other.rspec.pending'
       '2':
-        'name': 'entity.name.rspec'
+        'name': 'string'
     'match': '^\\s*(it|specify|scenario)\\s+(.*\\S)(?<!do)\\s*$'
     'name': 'meta.rspec.pending'
   'single-line-example':


### PR DESCRIPTION
This ensures that strings are displayed properly by most themes. 

Before:
![before](https://cloud.githubusercontent.com/assets/561180/3046163/26054246-e126-11e3-8375-eb57d7a15cad.png)

After:
![after](https://cloud.githubusercontent.com/assets/561180/3046166/2b0d513e-e126-11e3-87a7-a98d85502c20.png)
