### PR TITLE
Fix example grammar

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -1,7 +1,8 @@
+'name': 'RSpec'
+'scopeName': 'source.rspec'
 'fileTypes': [
   'spec.rb'
 ]
-'name': 'RSpec'
 'patterns': [
   {
     'match': '(?<!\\.)\\b(before|after|around)\\b(?![?!])'
@@ -11,16 +12,8 @@
     'include': '#behaviour'
   }
   {
-    'include': '#single-line-example'
-  }
-  {
-    'include': '#pending'
-  }
-  {
-    'include': '#example'
-  }
-  {
-    'include': '#example_name'
+    'match': '(?<!\\.)\\b(it|specify|example|scenario|pending|skip|xit|xspecify|xexample)\\b'
+    'name': 'keyword.other.exxample.rspec'
   }
   {
     'include': 'source.ruby'
@@ -56,46 +49,3 @@
         ]
       }
     ]
-  'example':
-    'begin': '^\\s*(it|specify|scenario)\\b'
-    'beginCaptures':
-      '1':
-        'name': 'keyword.other.rspec.rspec-example'
-    'end': '\\b(do)\\s*$'
-    'endCaptures':
-      '1':
-        'name': 'keyword.control.ruby.start-block'
-    'name': 'meta.rspec.rspec-example'
-    'patterns': [
-      {
-        'begin': '\\s([\'\"])'
-        'end': '\\1'
-        'name': 'string'
-      }
-      {
-        'begin': '(,)'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.separator.object.ruby'
-        'end': '\\s(?=do)'
-        'patterns': [
-          {
-            'include': 'source.ruby'
-          }
-        ]
-      }
-    ]
-  'pending':
-    'captures':
-      '1':
-        'name': 'keyword.other.rspec.pending'
-      '2':
-        'name': 'string'
-    'match': '^\\s*(it|specify|scenario)\\s+(.*\\S)(?<!do)\\s*$'
-    'name': 'meta.rspec.pending'
-  'single-line-example':
-    'captures':
-      '1':
-        'name': 'keyword.other.rspec.rspec-example'
-    'match': '^\\s*(it|specify|scenario)\\s*{'
-'scopeName': 'source.ruby.rspec'


### PR DESCRIPTION
This pull request fixes the RSpec example grammar.  

Simply put, it turns this:

![before](https://cloud.githubusercontent.com/assets/5688/4264734/be43166c-3c31-11e4-81fd-ba58515e3017.png)

into this:

![after](https://cloud.githubusercontent.com/assets/5688/4264736/c46e7a04-3c31-11e4-8054-19a1e62d090e.png)

The problem with the current grammar is two-fold:
1. It hasn't kept up with the times as new example keywords have been introduced.
2. It tries to be too clever by capturing Ruby constructs (e.g. strings and single-line block literals).

This PR fixes the above problems by:
1. Matching all the RSpec 3.1 example keywords into one `keyword.other.exxample.rspec` named group.
2. Ignoring the surrounding Ruby constructs, leaving them to be parsed by the `language-ruby` grammar.

In short, it's a back-to-the-basics kind of PR.
