### PR TITLE
I found that the `it` and `its` snippets were broken

### DIFF
--- a/snippets/language-rspec.cson
+++ b/snippets/language-rspec.cson
@@ -10,13 +10,13 @@
     'body': "describe ${1:Type}, '${2:description}' do\n  $0\nend"
   "it 'does something' do...end":
     'prefix': 'it'
-    'body': "it '${1:does something}'${2: do\n  $0\nend}"
+    'body': "it '${1:does something}' do\n  $0\nend"
   'it { should do something }':
     'prefix': 'iti'
     'body': "it { should ${1:matcher} }"
   "it 'should do something' do...end":
     'prefix': 'its'
-    'body': "it 'should ${1:do something}'${2: do\n  $0\nend}"
+    'body': "it 'should ${1:do something}' do\n  $0\nend"
   'it { is expected to do something }':
     'prefix': 'itis'
     'body': "it { is_expected.to ${1:matcher} }"


### PR DESCRIPTION
When I used `it` or `its` snippets it was generating the following

```
it 'does something' do
  [object, object]  
end
```
This fixes it inline with the expected behaviour based on other snippets