### PR TITLE
Update regex for should/should_not

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -12,7 +12,7 @@
     'name': 'keyword.other.example.rspec'
   }
   {
-    'match': '(should_not|should)'
+    'match': '\\b(should_not|should)\\b'
     'name': 'keyword.other.example.rspec'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -81,3 +81,37 @@ describe 'rspec grammar', ->
         {tokens} = grammar.tokenizeLine keyword
         expect(tokens[0].value).toEqual keyword
         expect(tokens[0].scopes).toEqual ['source.ruby.rspec', scope]
+
+  describe 'should', ->
+    it 'highlights it in an assertion', ->
+      {tokens} = grammar.tokenizeLine('count.should eq 42')
+
+      expect(tokens[1]).toEqual(
+        value: 'should',
+        scopes: ['source.ruby.rspec', 'keyword.other.example.rspec']
+      )
+
+    it 'does NOT highlight it inside another method', ->
+      {tokens} = grammar.tokenizeLine('it_should_behave_like "api controller"')
+
+      expect(tokens).toEqual([
+        value: 'it_should_behave_like "api controller"',
+        scopes: ['source.ruby.rspec']
+      ])
+
+  describe 'should_not', ->
+    it 'highlights it in an assertion', ->
+      {tokens} = grammar.tokenizeLine('count.should_not eq 42')
+
+      expect(tokens[1]).toEqual(
+        value: 'should_not',
+        scopes: ['source.ruby.rspec', 'keyword.other.example.rspec']
+      )
+
+    it 'does NOT highlight it inside another method', ->
+      {tokens} = grammar.tokenizeLine('it_should_not_behave_like "api controller"')
+
+      expect(tokens).toEqual([
+        value: 'it_should_not_behave_like "api controller"',
+        scopes: ['source.ruby.rspec']
+      ])


### PR DESCRIPTION
This PR fixes incorrect highlights of `should` and `should_not`.

## Example
<img width="511" alt="screen shot 2018-06-05 at 21 11 59" src="https://user-images.githubusercontent.com/6134283/40994589-4f74a8e0-6905-11e8-92a7-65c63bb14988.png">
