### PR TITLE
Add highlightling for focus and filter keywords

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -8,7 +8,7 @@
     'include': '#behaviour'
   }
   {
-    'match': '(?<!\\.)\\b(it|specify|example|scenario|pending|skip|xit|xspecify|xexample|expect)(?!\\s=|=)\\b'
+    'match': '(?<!\\.)\\b(it|specify|example|scenario|pending|skip|xit|fit|xspecify|xexample|expect)(?!\\s=|=)\\b'
     'name': 'keyword.other.example.rspec'
   }
   {
@@ -29,7 +29,7 @@
 ]
 'repository':
   'behaviour':
-    'begin': '^(RSpec)?(?:\\.|\\s*)(describe|context|feature)(?! =|=)\\b'
+    'begin': '^(RSpec)?(?:\\.|\\s*)(describe|context|fdescribe|fcontext|xdescribe|xcontext|feature)(?! =|=)\\b'
     'beginCaptures':
       '1':
         'name': 'support.class.ruby'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -73,7 +73,7 @@ describe 'rspec grammar', ->
 
   it 'tokenizes keywords', ->
     keywordLists =
-      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'xspecify', 'xexample', 'expect', 'should_not', 'should']
+      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'fit', 'xspecify', 'xexample', 'expect', 'should_not', 'should']
       'keyword.other.hook.rspec': ['before', 'after', 'around']
 
     for scope, list of keywordLists


### PR DESCRIPTION
Highlight `fit`, `fdescribe`, `fcontext`, `xdescribe`, and `xcontext` keywords which when prefixed by the letter 'f' or 'x' lose syntax highlighting and appear to be mistakes rather than keywords.